### PR TITLE
#166187823 User should be able to see Articles Paginated.

### DIFF
--- a/src/Articles/CSS/articlePagination.scss
+++ b/src/Articles/CSS/articlePagination.scss
@@ -1,0 +1,38 @@
+@import '../../commons/assets/variables/colors.scss';
+
+.paginate-article{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+}
+span{
+    line-height: 3.2;
+    font-family: Lato;
+    font-weight: 200;
+}
+
+ul {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 50%;
+    background: #cacaca;
+    margin: 0;
+    padding: 0;
+    padding-left: 6px;
+    padding-right: 6px;
+    text-align: center;
+
+}
+li {
+    display: block;
+    flex: 0 1 auto; 
+    list-style-type: none;
+    background: #fafafa;
+    width: 42px;
+    text-align: center;
+
+}
+button:hover:enabled{
+    border-color: lighten($primary-blue, 10%) !important;
+}

--- a/src/Articles/components/AllArticles.jsx
+++ b/src/Articles/components/AllArticles.jsx
@@ -5,17 +5,36 @@ import Article from "../../commons/components/Article";
 import { connect } from "react-redux";
 import getAllArticles from "../redux/actions/AllArticlesActions";
 import '../CSS/AllArticles.scss';
+import Pagination from './paginationComponent';
 
 export class AllArticles extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pageNumber: 1,
+    };
+  }
   componentDidMount() {
     const { getArticles } = this.props;
     getArticles();
   }
+
+  changePage = (apiCallUrl, increaseOrDecreasePageNumber ) => {
+    const { getArticles } = this.props;
+    const { pageNumber } = this.state;
+    this.setState({
+      pageNumber: pageNumber + increaseOrDecreasePageNumber
+    });
+
+    getArticles(apiCallUrl);
+  };
   render() {
-    const { items } = this.props
+    const { items, count, next, previous } = this.props
+    const { pageNumber } = this.state
     return (
       <div className='view-all-articles'>
         <Container>
+          <div className="myArticlu">
           {items.length != 0 ? (
             <div className='article-display-box'>
               {items.map(article => (
@@ -25,6 +44,13 @@ export class AllArticles extends Component {
           ) : (
             <h3 className='no-articles'>No Articles Available</h3>
           )}
+          </div>
+          <Pagination 
+            paginate={this.changePage}
+            currentPage={pageNumber}
+            count={count}
+            next={next}
+            previous={previous}/>
         </Container>
       </div>
     );
@@ -33,22 +59,28 @@ export class AllArticles extends Component {
 
 AllArticles.propTypes = {
   allArticles: PropTypes.any,
-  isRetrieving: PropTypes.bool
+  isRetrieving: PropTypes.bool,
+  count: PropTypes.number,
+  next: PropTypes.string,
+  previous: PropTypes.string,
 };
 
 AllArticles.defaultProps = {
   allArticles: [],
-  isRetrieving: false
+  isRetrieving: false,
+  count: 0,
+  next: "",
+  previous: "",
 };
 
 export const mapStateToProps = state => {
-  const { isRetrieving, items } = state.allArticleReducer;
-  return { isRetrieving, items };
+  const { isRetrieving, items, count, next, previous } = state.allArticleReducer;
+  return { isRetrieving, items, count, next, previous };
 };
 
 export const mapDispatchToProps = dispatch => ({
-  getArticles: () => {
-    dispatch(getAllArticles());
+  getArticles: (url) => {
+    dispatch(getAllArticles(url));
   }
 });
 

--- a/src/Articles/components/paginationComponent.jsx
+++ b/src/Articles/components/paginationComponent.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Button from "../../commons/components/Button";
+import '../CSS/articlePagination.scss';
+
+const Pagination = ({ paginate, currentPage, count, next, previous }) => {
+  const numberOfPages = Math.ceil(count / 6);
+  return (
+    <div className='paginate-article'>
+      <Button
+        buttonName=''
+        buttonClass='fa fa-backward'
+        buttonEvent={e => {
+          e.preventDefault();
+          paginate(previous, -1);
+        }}
+        disabled={!previous}
+      />
+      <span>
+        {currentPage || 1}
+        {" "}
+        {"/"}
+        {" "}
+        {numberOfPages} {"pages "}
+      </span>
+      <Button
+        buttonName=''
+        buttonClass='fa fa-forward'
+        buttonEvent={e => {
+          e.preventDefault();
+          paginate(next, 1);
+        }}
+        disabled={!next}
+      />
+    </div>
+  );
+};
+
+Pagination.defaultProps = {
+  next: "",
+  previous: ""
+};
+
+Pagination.propTypes = {
+  next: PropTypes.string,
+  currentPage: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+  previous: PropTypes.string,
+  paginate: PropTypes.func.isRequired
+};
+
+export default Pagination;

--- a/src/Articles/redux/actions/AllArticlesActions.js
+++ b/src/Articles/redux/actions/AllArticlesActions.js
@@ -1,5 +1,9 @@
 import axios from 'axios';
-import { GET_ALL_ARTICLES, GETTING_FAILED, BEGIN_GETTING_ARTICLES } from '../types';
+import {
+  GET_ALL_ARTICLES,
+  GETTING_FAILED,
+  BEGIN_GETTING_ARTICLES,
+} from '../types';
 
 export const beginFetchingArticles = () => ({
   type: BEGIN_GETTING_ARTICLES,
@@ -8,6 +12,9 @@ export const beginFetchingArticles = () => ({
 export const getArticlesSuccess = response => ({
   type: GET_ALL_ARTICLES,
   payload: response.data.results,
+  count: response.data.count,
+  next: response.data.next,
+  previous: response.data.previous,
 });
 
 export const gettingArticlesFail = error => ({
@@ -18,10 +25,14 @@ export const gettingArticlesFail = error => ({
   },
 });
 
-const getAllArticles = () => (dispatch) => {
+const getAllArticles = (articlePageUrl) => (dispatch) => {
   dispatch(beginFetchingArticles());
+  let url = 'https://ah-backend-realers-staging.herokuapp.com/api/articles/?limit=6&offset=0';
 
-  return axios.get('https://ah-backend-realers-staging.herokuapp.com/api/articles/')
+  if (articlePageUrl) {
+    url = articlePageUrl;
+  }
+  return axios.get(url)
     .then(response => dispatch(getArticlesSuccess(response)))
     .catch((error) => {
       dispatch(gettingArticlesFail(error));

--- a/src/Articles/redux/reducers/allArticlesReducer.jsx
+++ b/src/Articles/redux/reducers/allArticlesReducer.jsx
@@ -12,8 +12,12 @@ const allArticleReducer = (state = initialState, action) => {
       return {
         ...state,
         items: action.payload,
+        count: action.count,
+        next: action.next,
+        previous: action.previous,
         isRetrieving: false,
         message: 'All Articles fetched',
+
       };
     case BEGIN_GETTING_ARTICLES:
       return {

--- a/src/Articles/tests/components/__snapshots__/paginationComponent.test.jsx.snap
+++ b/src/Articles/tests/components/__snapshots__/paginationComponent.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination this should render without a problem 1`] = `ReactWrapper {}`;

--- a/src/Articles/tests/components/paginationComponent.test.jsx
+++ b/src/Articles/tests/components/paginationComponent.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import Pagination from '../../components/paginationComponent';
+import Button from '../../../commons/components/Button';
+
+describe('Pagination', () => {
+  const props = {
+    previous: null,
+    next: 'next',
+    paginate: jest.fn(),
+    count: 20,
+  };
+  let wrapper = mount(<Pagination {...props} />);
+
+  it('this should render without a problem', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  const prevButton = wrapper.find(Button).at(0);
+  const nxtButton = wrapper.find(Button).at(1);
+
+  it('should disable buttons if null', () => {
+    expect(prevButton.props().disabled).toBe(true);
+    expect(nxtButton.props().disabled).toBe(false);
+  });
+
+
+  it('should call the paginate function on button click', () => {
+    const event = {
+      target: {
+        type: 'button',
+        name: '',
+      },
+      preventDefault: jest.fn(),
+    };
+
+    nxtButton.simulate('click', event);
+    expect(props.paginate).toBeCalled();
+    prevButton.simulate('click', event);
+
+
+    props.previous = 'previous';
+    wrapper = mount(<Pagination {...props} />);
+    wrapper.find(Button).at(0).simulate('click', event);
+    expect(props.paginate).toBeCalled();
+  });
+});

--- a/src/Articles/tests/redux/actions/allArticlesActions.test.jsx
+++ b/src/Articles/tests/redux/actions/allArticlesActions.test.jsx
@@ -1,36 +1,40 @@
 /* eslint-disable no-undef */
-import thunk from 'redux-thunk';
-import moxios from 'moxios';
-import configureMockStore from 'redux-mock-store';
-import ARTICLE_DATA from '../../../../__mock__/articleData';
-import { GET_ALL_ARTICLES, GETTING_FAILED, BEGIN_GETTING_ARTICLES } from '../../../redux/types';
-import getallArticles from '../../../redux/actions/AllArticlesActions';
+import thunk from "redux-thunk";
+import moxios from "moxios";
+import configureMockStore from "redux-mock-store";
+import ARTICLE_DATA from "../../../../__mock__/articleData";
+import {
+  GET_ALL_ARTICLES,
+  GETTING_FAILED,
+  BEGIN_GETTING_ARTICLES
+} from "../../../redux/types";
+import getallArticles from "../../../redux/actions/AllArticlesActions";
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-describe('', () => {
+describe("", () => {
   beforeEach(() => moxios.install());
   afterEach(() => moxios.uninstall());
 
-  it('should start get and succeed', () => {
-    moxios.stubRequest('https://ah-backend-realers-staging.herokuapp.com/api/articles/', {
-      status: 200,
-      response: {
-        data: {
-          results: ARTICLE_DATA,
-        },
-      },
+  it("should start get and succeed", () => {
+    moxios.wait(() => {
+      moxios.requests.mostRecent().respondWith({
+        status: 200,
+        response: {
+          results: ARTICLE_DATA
+        }
+      });
     });
 
     const expectedActions = [
       {
-        type: BEGIN_GETTING_ARTICLES,
+        type: BEGIN_GETTING_ARTICLES
       },
       {
         type: GET_ALL_ARTICLES,
-        payload: ARTICLE_DATA,
-      },
+        payload: ARTICLE_DATA
+      }
     ];
     const store = mockStore();
     return store.dispatch(getallArticles()).then(() => {
@@ -38,22 +42,25 @@ describe('', () => {
     });
   });
 
-  it('this triggers a failed getting action because of the error', () => {
-    moxios.stubRequest('https://ah-backend-realers-staging.herokuapp.com/api/articles/', {
-      status: 400,
+  it("this triggers a failed getting action because of the error", () => {
+    moxios.wait(() => {
+      moxios.requests.mostRecent().respondWith({
+        status: 400,
+        response: {}
+      });
     });
 
     const expectedActions = [
       {
-        type: BEGIN_GETTING_ARTICLES,
+        type: BEGIN_GETTING_ARTICLES
       },
       {
         type: GETTING_FAILED,
         payload: {
           status: false,
-          error: 400,
-        },
-      },
+          error: 400
+        }
+      }
     ];
     const store = mockStore();
     return store.dispatch(getallArticles()).then(() => {

--- a/src/commons/components/Button.jsx
+++ b/src/commons/components/Button.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Button = (props) => {
+  const {
+    buttonEvent, disabled, buttonClass, buttonName,
+  } = props;
+
+  return (
+    <button
+      className={buttonClass}
+      type="button"
+      onClick={buttonEvent}
+      disabled={disabled}
+    >
+      {buttonName}
+    </button>
+  );
+};
+
+Button.defaultProps = {
+  disabled: false,
+};
+
+Button.propTypes = {
+  disabled: PropTypes.bool,
+  buttonName: PropTypes.string.isRequired,
+  buttonClass: PropTypes.string.isRequired,
+  buttonEvent: PropTypes.func.isRequired,
+};
+
+export default Button;

--- a/src/commons/tests/components/Button.test.jsx
+++ b/src/commons/tests/components/Button.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import Button from '../../components/Button';
+
+describe('Button Component', () => {
+  it('Renders a button component', () => {
+
+    const buttonEvent = jest.fn();
+    const ButtonComponent = shallow(<Button buttonName="Login" buttonClass="btn btn-base" buttonEvent={buttonEvent} />);
+
+    expect(ButtonComponent.find('.btn').text()).toBe('Login');
+    expect(ButtonComponent.find('.btn').hasClass('btn btn-base')).toBe(true);
+
+    ButtonComponent.find('.btn').simulate('click');
+    expect(buttonEvent).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

Add Pagination support for project

#### Description of Task to be completed?

- Add provision for pagination to view all articles
- Add pagination for search results

#### How should this be manually tested?

* -	Git fetch this repo locally in the terminal with `git fetch origin ft-article-pagination-166187823
* -	Run application: `npm start`
* -	Navigate to the: `/articles` route
The review app is [here.](https://authors-frontend-staging-pr-23.herokuapp.com/articles)

#### Any background context you want to provide?

- Have added pagination support for the project so that 6 stories are shown per page to prevent excessive scrolling..

#### What are the relevant pivotal tracker stories?

#[#166187823](https://www.pivotaltracker.com/story/show/#166187823)

#### Screenshots:

<img width="1440" alt="Screenshot 2019-07-24 at 19 04 02" src="https://user-images.githubusercontent.com/32802973/61852906-4a4e1e00-aec3-11e9-8acc-aa02bc76abba.png">

<img width="1440" alt="Screenshot 2019-07-24 at 19 04 10" src="https://user-images.githubusercontent.com/32802973/61852925-5043ff00-aec3-11e9-85d5-44ad95189e6b.png">

<img width="1440" alt="Screenshot 2019-07-24 at 19 04 22" src="https://user-images.githubusercontent.com/32802973/61852936-5508b300-aec3-11e9-8aa0-3fa7eb897503.png">
